### PR TITLE
Requirement version constraints and API fixes

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,4 +3,4 @@ South==1.0
 argparse
 distribute
 wsgiref
-djangorestframework>=2.3
+djangorestframework>=2.3,<3.0

--- a/whats_open/templates/layouts/about.html
+++ b/whats_open/templates/layouts/about.html
@@ -1,3 +1,4 @@
+{% load staticfiles%}
 {% block about %}
 <div class="row about-content">
     <div class="col-md-10 col-md-offset-1">    

--- a/whats_open/templates/layouts/footer.html
+++ b/whats_open/templates/layouts/footer.html
@@ -1,3 +1,4 @@
+{% load staticfiles%}
 {% block footer %}
 <div id="footer">
     <div class="footer-row">

--- a/whats_open/templates/layouts/head.html
+++ b/whats_open/templates/layouts/head.html
@@ -1,3 +1,4 @@
+{% load staticfiles%}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <meta name="description=" content="What's Open is a dynamic web application that lets you easily find out which on-campus locations are currently available. It's a simple alternative to searching for Mason's campus hours and filtering though them to figure out which ones are open.">

--- a/whats_open/templates/layouts/navbar.html
+++ b/whats_open/templates/layouts/navbar.html
@@ -1,3 +1,4 @@
+{% load staticfiles%}
 {% block nav %}
 <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="navbar-header">

--- a/whats_open/website/serializers.py
+++ b/whats_open/website/serializers.py
@@ -16,9 +16,8 @@ class ScheduleSerializer(serializers.ModelSerializer):
         model = Schedule
 
 class FacilitySerializer(serializers.ModelSerializer):
-    category = serializers.RelatedField(many=False)
-    main_schedule = serializers.RelatedField(many=False)
-    special_schedules = serializers.RelatedField(many=True)
+    main_schedule = ScheduleSerializer()
+    special_schedules = ScheduleSerializer(many=True)
 
     class Meta:
         model = Facility


### PR DESCRIPTION
REST Framework has deprecated and removed some calls being used which resulted in API calls not working. Constrained version to stay on 2.x line. 

Serializer Change broke API call when retrieving open_times from a schedule. Reverted

Add static loads to fix template layout rendering of static assets.
